### PR TITLE
Consider values close to 0.0 as 0.0

### DIFF
--- a/src/blocks_model.jl
+++ b/src/blocks_model.jl
@@ -126,7 +126,7 @@ function _k_area(cover::Array{Float64}, k_max::Float64)::Float64
         return 0.0
     end
 
-    return 1 - (sum(cover) / k_max)
+    return 1.0 - (sum(cover) / k_max)
 end
 
 function new_medium_size_class(


### PR DESCRIPTION
Current implementation spams the terminal with warning messages when running with no disturbances as cover resolves to be a tiny bit over available area.

The change in this PR handles tiny differences as being functionally equivalent (e.g., $a - b \approx 0.0$)