### PR TITLE
Changes to handle small size classes

### DIFF
--- a/src/blocks_model.jl
+++ b/src/blocks_model.jl
@@ -201,7 +201,7 @@ function new_large_size_class(
     n_new_corals::Float64 = 0.0
     for cover_block in prev_size_class.cover_blocks[blocks_within_range]
         new_diameter_density = cover_block.diameter_density * prev_size_class.survival_rate
-        interval_width = cover_block.interval[2] + prev_growth  - max(
+        interval_width = cover_block.interval[2] + prev_growth - max(
             cover_block.interval[1] + prev_growth, current_size_class.interval[1]
         )
         n_new_corals += new_diameter_density * interval_width


### PR DESCRIPTION
Previous approach kills off any settled corals that did not move up to the next size class.
