### PR TITLE
Relax julia version requirement

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ YAXArrays = "c21b50f5-aa40-41ea-b809-c0f5e47bfa5c"
 [compat]
 DataStructures = "0.18.20"
 YAXArrays = "0.5.8"
-julia = "1.10.4"
+julia = "1"
 
 [weakdeps]
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"


### PR DESCRIPTION
The previous requirement of 1.10.4 was causing issues in contexts where another version of julia was being used. Since I don't see a particular reason why only 1.10.4 should be accepted, I am relaxing this requirement to try to solve those issues.