### PR TITLE
Fix wrong growth rate being applied in terminal class transfer_and_grow

### DIFF
--- a/src/timestep.jl
+++ b/src/timestep.jl
@@ -572,7 +572,7 @@ function timestep!(
     transfer_and_grow!(
         functional_group.size_classes[end],
         functional_group.terminal_class,
-        growth_rate[end]
+        growth_rate[end-1]
     )
 
     n_classes::Int64 = length(functional_group.size_classes)


### PR DESCRIPTION
In the previous version we were wrongly using the growth rate of the terminal size class for the one before the terminal size class corals. Because of that, once the corals got to the size class one before the terminal they got "stuck" there, never growing.