### PR TITLE
Exclude largest sizeclass from linear extension scale factor calculation

### DIFF
--- a/src/linear_extension.jl
+++ b/src/linear_extension.jl
@@ -59,25 +59,34 @@ function linear_extension_scale_factors(
     bin_edges::AbstractMatrix{Float64},
     max_projected_cover::Float64
 )::Float64
-    total_cover::Float64 = sum(C_cover_t)
+    # Target here refers to all size classes except the last one of each functional group
+    # since these don't grow
+    target_linear_extensions = @view linear_extensions[:, 1:end-1]
+    target_bin_edges = @view bin_edges[:, 1:end-1]
+    target_C_cover_t = @view C_cover_t[:, 1:end-1]
+
+    total_cover::Float64 = sum(target_C_cover_t)
 
     # Average density for each functional group and size class
-    size_class_densities::Matrix{Float64} = _size_class_densities(C_cover_t, bin_edges)
+    size_class_densities::Matrix{Float64} = _size_class_densities(target_C_cover_t, target_bin_edges)
 
     # Projected coral cover at t+1
     projected_cover::Float64 = _projected_cover(
-        size_class_densities, linear_extensions, bin_edges
+        size_class_densities, target_linear_extensions, target_bin_edges
     )
 
     adjusted_projected_cover::Float64 = _adjusted_projected_cover(
-        total_cover, projected_cover, max_projected_cover, habitable_area
+        total_cover,
+        projected_cover,
+        max_projected_cover - total_cover,
+        habitable_area - total_cover
     )
 
     # Solve quadratic equation
-    a::Float64 = _quadratic_coeff(size_class_densities, linear_extensions, Δd(bin_edges, 1))
-    b::Float64 = _linear_coeff(size_class_densities, linear_extensions, Δd(bin_edges, 2))
+    a::Float64 = _quadratic_coeff(size_class_densities, target_linear_extensions, Δd(target_bin_edges, 1))
+    b::Float64 = _linear_coeff(size_class_densities, target_linear_extensions, Δd(target_bin_edges, 2))
     c::Float64 = _constant_coeff(
-        size_class_densities, adjusted_projected_cover, Δd(bin_edges, 3)
+        size_class_densities, adjusted_projected_cover, Δd(target_bin_edges, 3)
     )
 
     return (sqrt((b^2) - (4 * a * c)) - (b)) / (2 * a)
@@ -89,43 +98,13 @@ function linear_extension_scale_factors(
     bin_edges::AbstractMatrix{Float64},
     max_projected_cover::AbstractVector{Float64}
 )::AbstractVector{Float64}
-    # This is assuming the last functional group doesn't grow. For more details read this
-    # function's docstring
-    loc_C_cover_not_growable = dropdims(sum(C_cover_t[:, end, :], dims=1), dims=1)
-    C_cover_t_growable = C_cover_t[:, 1:end-1, :]
-
-    # Total cover for each location
-    loc_C_cover::Vector{Float64} = dropdims(sum(C_cover_t_growable, dims=(1, 2)); dims=(1, 2))
-
-    # Average density for each functional group, size class and location
-    size_class_densities::Array{Float64,3} = _size_class_densities(
-        C_cover_t_growable, bin_edges[:, 1:end-1]
+    linear_extension_scale_factors.(
+        eachslice(C_cover_t, dims=3),
+        loc_habitable_areas,
+        Ref(linear_extensions),
+        Ref(bin_edges),
+        max_projected_cover
     )
-
-    # Projected coral cover for each location at t+1
-    projected_cover::Vector{Float64} = _projected_cover(
-        size_class_densities, linear_extensions[:, 1:end-1], bin_edges[:, 1:end-1]
-    )
-
-    adjusted_projected_cover::Vector{Float64} = _adjusted_projected_cover(
-        loc_C_cover,
-        projected_cover,
-        max_projected_cover .- loc_C_cover_not_growable,
-        loc_habitable_areas .- loc_C_cover_not_growable
-    )
-
-    # Solve quadratic equation
-    a::Vector{Float64} = _quadratic_coeff(
-        size_class_densities, linear_extensions[:, 1:end-1], Δd(bin_edges[:, 1:end-1], 1)
-    )
-    b::Vector{Float64} = _linear_coeff(
-        size_class_densities, linear_extensions[:, 1:end-1], Δd(bin_edges[:, 1:end-1], 2)
-    )
-    c::Vector{Float64} = _constant_coeff(
-        size_class_densities, adjusted_projected_cover, Δd(bin_edges[:, 1:end-1], 3)
-    )
-
-    return (sqrt.((b .^ 2) .- (4 .* a .* c)) .- (b)) ./ (2 .* a)
 end
 
 Δd(

--- a/src/linear_extension.jl
+++ b/src/linear_extension.jl
@@ -38,7 +38,12 @@ end
 """
     adjusted_linear_extension(C_cover_t::AbstractArray{Float64,3}, loc_habitable_areas::AbstractVector{Float64}, linear_extensions::AbstractMatrix{Float64}, bin_edges::AbstractMatrix{Float64}, max_projected_cover::AbstractVector{Float64})
 
-Adjusted linear extension.
+Adjusted linear extension. It assumes the last functional group doesn't grow. Therefore,
+the last size class of each functional group are excluded from this calculation to prevent a
+rounding error that sometimes occurs when almost all of the cover is concentrated in the
+last size class of some functional groups and the growth (correspondent to the remaining
+size classes) is marginal and, because of rounding, sometimes makes the projected_cover be
+slightly larger than loc_C_cover for some locs.
 
 # Arguments
 - `C_cover_t` : Cover at previous timestep
@@ -84,30 +89,40 @@ function linear_extension_scale_factors(
     bin_edges::AbstractMatrix{Float64},
     max_projected_cover::AbstractVector{Float64}
 )::AbstractVector{Float64}
+    # This is assuming the last functional group doesn't grow. For more details read this
+    # function's docstring
+    loc_C_cover_not_growable = dropdims(sum(C_cover_t[:, end, :], dims=1), dims=1)
+    C_cover_t_growable = C_cover_t[:, 1:end-1, :]
+
     # Total cover for each location
-    loc_C_cover::Vector{Float64} = dropdims(sum(C_cover_t, dims=(1, 2)); dims=(1, 2))
+    loc_C_cover::Vector{Float64} = dropdims(sum(C_cover_t_growable, dims=(1, 2)); dims=(1, 2))
 
     # Average density for each functional group, size class and location
-    size_class_densities::Array{Float64,3} = _size_class_densities(C_cover_t, bin_edges)
+    size_class_densities::Array{Float64,3} = _size_class_densities(
+        C_cover_t_growable, bin_edges[:, 1:end-1]
+    )
 
     # Projected coral cover for each location at t+1
     projected_cover::Vector{Float64} = _projected_cover(
-        size_class_densities, linear_extensions, bin_edges
+        size_class_densities, linear_extensions[:, 1:end-1], bin_edges[:, 1:end-1]
     )
 
     adjusted_projected_cover::Vector{Float64} = _adjusted_projected_cover(
-        loc_C_cover, projected_cover, max_projected_cover, loc_habitable_areas
+        loc_C_cover,
+        projected_cover,
+        max_projected_cover .- loc_C_cover_not_growable,
+        loc_habitable_areas .- loc_C_cover_not_growable
     )
 
     # Solve quadratic equation
     a::Vector{Float64} = _quadratic_coeff(
-        size_class_densities, linear_extensions, Δd(bin_edges, 1)
+        size_class_densities, linear_extensions[:, 1:end-1], Δd(bin_edges[:, 1:end-1], 1)
     )
     b::Vector{Float64} = _linear_coeff(
-        size_class_densities, linear_extensions, Δd(bin_edges, 2)
+        size_class_densities, linear_extensions[:, 1:end-1], Δd(bin_edges[:, 1:end-1], 2)
     )
     c::Vector{Float64} = _constant_coeff(
-        size_class_densities, adjusted_projected_cover, Δd(bin_edges, 3)
+        size_class_densities, adjusted_projected_cover, Δd(bin_edges[:, 1:end-1], 3)
     )
 
     return (sqrt.((b .^ 2) .- (4 .* a .* c)) .- (b)) ./ (2 .* a)


### PR DESCRIPTION
This was done to prevent a rounding error that occur sometimes. The issue and fix explanations (copied from the function docstring) is: "the last size class of each functional group are excluded from this calculation to prevent a rounding error that sometimes occurs when almost all of the cover is concentrated in the last size class of some functional groups and the growth (correspondent to the remaining size classes) is marginal and, because of rounding, sometimes makes the projected_cover be
slightly larger than loc_C_cover for some locs."


