### PR TITLE
Remove broadcasting and use mutable StaticArrays as cache

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.7"
 manifest_format = "2.0"
-project_hash = "adf0d4ad50347d7aa05c2d2838ff7a3894b459e5"
+project_hash = "2361b4932cef18cddf14a5208b07306ce3ec1012"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "27cecae79e5cc9935255f90c53bb831cc3c870d7"

--- a/Project.toml
+++ b/Project.toml
@@ -5,18 +5,20 @@ version = "1.1.4"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 YAXArrays = "c21b50f5-aa40-41ea-b809-c0f5e47bfa5c"
-
-[compat]
-DataStructures = "0.18.20"
-YAXArrays = "0.6, 0.7"
-julia = "1"
 
 [weakdeps]
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [extensions]
 CoralBloxPlotExt = "Makie"
+
+[compat]
+DataStructures = "0.18.20"
+StaticArrays = "1.9.15"
+YAXArrays = "0.6, 0.7"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/timestep.jl
+++ b/src/timestep.jl
@@ -1,3 +1,4 @@
+using StaticArrays
 using DataStructures: CircularBuffer
 
 struct SizeClass
@@ -10,7 +11,7 @@ struct SizeClass
 
     # Caches
     buf_new::Vector{Float64}
-    movement_cache::Vector{Float64}  # 3 elements
+    movement_cache::MVector{3,Float64}
 end
 
 
@@ -37,7 +38,7 @@ function SizeClass(
     push!(block_densities, density)
 
     buf_new::Vector{Float64} = zeros(capacity)
-    cache::Vector{Float64} = zeros(3)
+    cache::MVector{3,Float64} = @MVector zeros(3)
     return SizeClass(
         lower_bound,
         upper_bound,
@@ -85,7 +86,12 @@ function FunctionalGroup(
     upper_bounds::AbstractVector{Float64},
     cover::AbstractVector{Float64}
 )::FunctionalGroup
-    size_classes::Vector{SizeClass} = SizeClass.(lower_bounds[1:end-1], upper_bounds[1:end-1], cover[1:end-1])
+    num_sc = length(lower_bounds[1:end-1])
+    size_classes::Vector{SizeClass} = Vector(undef, num_sc)
+    for i in 1:num_sc
+        size_classes[i] = SizeClass(lower_bounds[i], upper_bounds[i], cover[i])
+    end
+
     terminal_class::TerminalClass = TerminalClass(lower_bounds[end], upper_bounds[end], cover[end])
 
     return FunctionalGroup(
@@ -186,7 +192,10 @@ function apply_mortality!(
     functional_group::FunctionalGroup,
     survival_rate::Union{Vector{Float64},SubArray{Float64,1}}
 )::Nothing
-    apply_mortality!.(functional_group.size_classes, survival_rate[1:end-1])
+    for sc in 1:length(functional_group.size_classes)-1
+        apply_mortality!(functional_group.size_classes[sc], survival_rate[sc])
+    end
+
     functional_group.terminal_class.density *= survival_rate[end]
 
     return nothing
@@ -612,7 +621,7 @@ function timestep!(
     growth_rate::Matrix{Float64},
     survival_rate::Matrix{Float64}
 )::Nothing
-    for r in axes(growth_rate, 1)
+    @inbounds for r in axes(growth_rate, 1)
         timestep!(functional_groups[r], recruitment[r], @view(growth_rate[r, :]), @view(survival_rate[r, :]))
     end
 


### PR DESCRIPTION
Avoiding allocations by removing broadcasts and switching to a mutable StaticArray for the small 3-element cache