### PR TITLE
perf: reduce allocations and per-timestep recomputation in linear extension and timestep hot paths

### DIFF
--- a/src/linear_extension.jl
+++ b/src/linear_extension.jl
@@ -35,7 +35,77 @@ function _diameter_coef(
 end
 
 """
-    adjusted_linear_extension(C_cover_t::AbstractArray{Float64,3}, loc_habitable_areas::AbstractVector{Float64}, linear_extensions::AbstractMatrix{Float64}, bin_edges::AbstractMatrix{Float64}, max_projected_cover::AbstractVector{Float64})
+    LinearExtensionCache(bin_edges)
+
+Pre-computed Δd matrices derived from `bin_edges`. Construct once per domain/scenario
+and pass to `linear_extension_scale_factors` to avoid recomputing these constant matrices
+on every timestep.
+"""
+struct LinearExtensionCache
+    Δ¹d::Matrix{Float64}
+    Δ²d::Matrix{Float64}
+    Δ³d::Matrix{Float64}
+end
+function LinearExtensionCache(bin_edges::AbstractMatrix{Float64})
+    tgt = @view bin_edges[:, 1:(end - 1)]
+    return LinearExtensionCache(Δd(tgt, 1), Δd(tgt, 2), Δd(tgt, 3))
+end
+
+# Private: computation with pre-computed Δd matrices and target_linear_extensions view.
+# All public overloads delegate here after computing Δd once.
+#
+# density_i = (12/π) * C_i / Δ³_i is substituted into all coefficient expressions:
+#   projected_cover = Σ C*(3*le²*Δ1/Δ3 + 3*le*Δ2/Δ3 + 1)
+#   a = (36/π) * Σ C*le²*Δ1/Δ3
+#   b = (36/π) * Σ C*le*Δ2/Δ3
+#   c = (12/π) * (total_cover - adjusted_projected_cover)
+# All three accumulators are computed in a single pass to avoid any intermediate allocations.
+function _linear_extension_scale_factors_core(
+    C_cover_t::AbstractMatrix{Float64},
+    habitable_area::Float64,
+    target_linear_extensions::AbstractMatrix{Float64},
+    max_projected_cover::Float64,
+    Δ¹d::AbstractMatrix{Float64},
+    Δ²d::AbstractMatrix{Float64},
+    Δ³d::AbstractMatrix{Float64},
+)::Float64
+    target_C_cover_t = @view C_cover_t[:, 1:(end - 1)]
+    total_cover::Float64 = sum(target_C_cover_t)
+    non_target_total_cover = sum(C_cover_t[:, end])
+
+    projected_cover::Float64 = 0.0
+    a_acc::Float64 = 0.0
+    b_acc::Float64 = 0.0
+    @inbounds for j ∈ axes(target_C_cover_t, 2), i ∈ axes(target_C_cover_t, 1)
+        c_ij = target_C_cover_t[i, j]
+        le = target_linear_extensions[i, j]
+        Δ1 = Δ¹d[i, j]
+        Δ2 = Δ²d[i, j]
+        Δ3 = Δ³d[i, j]
+        c_over_Δ3 = c_ij / Δ3
+        projected_cover += c_ij + c_over_Δ3 * (3 * le^2 * Δ1 + 3 * le * Δ2)
+        a_acc += c_over_Δ3 * le^2 * Δ1
+        b_acc += c_over_Δ3 * le * Δ2
+    end
+
+    a::Float64 = (36 / π) * a_acc
+    b::Float64 = (36 / π) * b_acc
+
+    adjusted_projected_cover::Float64 = _adjusted_projected_cover(
+        total_cover,
+        projected_cover,
+        max_projected_cover - non_target_total_cover,
+        habitable_area - non_target_total_cover,
+    )
+
+    c::Float64 = (12 / π) * (total_cover - adjusted_projected_cover)
+
+    return (sqrt((b^2) - (4 * a * c)) - b) / (2 * a)
+end
+
+# Public scalar: computes Δd once then delegates to core.
+"""
+    linear_extension_scale_factors(C_cover_t::AbstractArray{Float64,3}, loc_habitable_areas::AbstractVector{Float64}, linear_extensions::AbstractMatrix{Float64}, bin_edges::AbstractMatrix{Float64}, max_projected_cover::AbstractVector{Float64})
 
 Adjusted linear extension. It assumes the last functional group doesn't grow. Therefore,
 the last size class of each functional group are excluded from this calculation to prevent a
@@ -58,45 +128,22 @@ function linear_extension_scale_factors(
     bin_edges::AbstractMatrix{Float64},
     max_projected_cover::Float64,
 )::Float64
-    # Target here refers to all size classes except the last one of each functional group
-    # since these don't grow
-    target_linear_extensions = @view linear_extensions[:, 1:(end - 1)]
     target_bin_edges = @view bin_edges[:, 1:(end - 1)]
-    target_C_cover_t = @view C_cover_t[:, 1:(end - 1)]
-
-    total_cover::Float64 = sum(target_C_cover_t)
-    non_target_total_cover = sum(C_cover_t[:, end])
-
-    # Average density for each functional group and size class
-    size_class_densities::Matrix{Float64} = _size_class_densities(
-        target_C_cover_t, target_bin_edges
+    Δ¹d = Δd(target_bin_edges, 1)
+    Δ²d = Δd(target_bin_edges, 2)
+    Δ³d = Δd(target_bin_edges, 3)
+    return _linear_extension_scale_factors_core(
+        C_cover_t,
+        habitable_area,
+        @view(linear_extensions[:, 1:(end - 1)]),
+        max_projected_cover,
+        Δ¹d,
+        Δ²d,
+        Δ³d,
     )
-
-    # Projected coral cover at t+1
-    projected_cover::Float64 = _projected_cover(
-        size_class_densities, target_linear_extensions, target_bin_edges
-    )
-
-    adjusted_projected_cover::Float64 = _adjusted_projected_cover(
-        total_cover,
-        projected_cover,
-        max_projected_cover - non_target_total_cover,
-        habitable_area - non_target_total_cover,
-    )
-
-    # Solve quadratic equation
-    a::Float64 = _quadratic_coeff(
-        size_class_densities, target_linear_extensions, Δd(target_bin_edges, 1)
-    )
-    b::Float64 = _linear_coeff(
-        size_class_densities, target_linear_extensions, Δd(target_bin_edges, 2)
-    )
-    c::Float64 = _constant_coeff(
-        size_class_densities, adjusted_projected_cover, Δd(target_bin_edges, 3)
-    )
-
-    return (sqrt((b^2) - (4 * a * c)) - (b)) / (2 * a)
 end
+
+# Public vector: computes Δd once for the whole batch, then calls core per location.
 function linear_extension_scale_factors(
     C_cover_t::AbstractArray{Float64, 3},
     loc_habitable_areas::AbstractVector{Float64},
@@ -104,22 +151,43 @@ function linear_extension_scale_factors(
     bin_edges::AbstractMatrix{Float64},
     max_projected_cover::AbstractVector{Float64},
 )::AbstractVector{Float64}
+    return linear_extension_scale_factors(
+        C_cover_t,
+        loc_habitable_areas,
+        linear_extensions,
+        LinearExtensionCache(bin_edges),
+        max_projected_cover,
+    )
+end
+
+# Public vector with a LinearExtensionCache — for callers that pre-compute the cache
+# once before a timestep loop to avoid recomputing constant Δd matrices each call.
+function linear_extension_scale_factors(
+    C_cover_t::AbstractArray{Float64, 3},
+    loc_habitable_areas::AbstractVector{Float64},
+    linear_extensions::AbstractMatrix{Float64},
+    cache::LinearExtensionCache,
+    max_projected_cover::AbstractVector{Float64},
+)::AbstractVector{Float64}
     n = size(C_cover_t, 3)
     result = Vector{Float64}(undef, n)
+    target_lin_ext = @view linear_extensions[:, 1:(end - 1)]
     @views for i ∈ 1:n
-        result[i] = linear_extension_scale_factors(
+        result[i] = _linear_extension_scale_factors_core(
             C_cover_t[:, :, i],
             loc_habitable_areas[i],
-            linear_extensions,
-            bin_edges,
+            target_lin_ext,
             max_projected_cover[i],
+            cache.Δ¹d,
+            cache.Δ²d,
+            cache.Δ³d,
         )
     end
     return result
 end
 
-Δd(bin_edges::AbstractMatrix{Float64}, n::Int64)::Matrix{Float64} =
-    ((bin_edges[:, 2:end] .^ n) .- (bin_edges[:, 1:(end - 1)] .^ n))
+@inline @views Δd(bin_edges::AbstractMatrix{Float64}, n::Int64)::Matrix{Float64} =
+    @. ((bin_edges[:, 2:end]^n) - (bin_edges[:, 1:(end - 1)]^n))
 
 _size_class_densities(
     C_cover_t::AbstractMatrix{Float64}, bin_edges::AbstractMatrix{Float64}

--- a/src/timestep.jl
+++ b/src/timestep.jl
@@ -425,12 +425,11 @@ function transfer_blocks!(
 )::Nothing
 
     # Blocks that exceed this bound will move to the next size class
+    # block_upper_bounds is sorted descending; binary search for the cutoff
     moving_bound::Float64 = prev_class.upper_bound - prev_growth_rate
-    for block_idx ∈ 1:n_blocks(prev_class)
-        # Skip blocks that are not migrating
-        if prev_class.block_upper_bounds[block_idx] <= moving_bound
-            break
-        end
+    n_migrating::Int64 =
+        searchsortedfirst(prev_class.block_upper_bounds, moving_bound; rev=true) - 1
+    for block_idx ∈ 1:n_migrating
         prev_class.movement_cache .= calculate_new_block!(
             prev_class.block_lower_bounds[block_idx],
             prev_class.block_upper_bounds[block_idx],

--- a/src/timestep.jl
+++ b/src/timestep.jl
@@ -429,6 +429,7 @@ function transfer_blocks!(
     # Blocks that exceed this bound will move to the next size class
     # block_upper_bounds is sorted descending; binary search for the cutoff
     moving_bound::Float64 = prev_class.upper_bound - prev_growth_rate
+    # Skip blocks that are not migrating
     n_migrating::Int64 =
         searchsortedfirst(prev_class.block_upper_bounds, moving_bound; rev=true) - 1
     for block_idx ∈ 1:n_migrating

--- a/src/timestep.jl
+++ b/src/timestep.jl
@@ -15,7 +15,7 @@ struct SizeClass
 end
 
 function SizeClass(
-    lower_bound::Float64, upper_bound::Float64, cover::Float64; capacity::Int64=256
+    lower_bound::Float64, upper_bound::Float64, cover::Float64; capacity::Int64=16
 )::SizeClass
     area_factor::Float64 = π / 12 * (upper_bound^3 - lower_bound^3)
     density::Float64 = cover / area_factor
@@ -81,7 +81,7 @@ function FunctionalGroup(
     upper_bounds::AbstractVector{Float64},
     cover::AbstractVector{Float64},
 )::FunctionalGroup
-    num_sc = length(lower_bounds[1:(end - 1)])
+    num_sc = length(lower_bounds) - 1
     size_classes::Vector{SizeClass} = Vector(undef, num_sc)
     for i ∈ 1:num_sc
         size_classes[i] = SizeClass(lower_bounds[i], upper_bounds[i], cover[i])
@@ -90,8 +90,6 @@ function FunctionalGroup(
     terminal_class::TerminalClass = TerminalClass(
         lower_bounds[end], upper_bounds[end], cover[end]
     )
-
-    return FunctionalGroup(size_classes, terminal_class)
 
     return FunctionalGroup(size_classes, terminal_class)
 end
@@ -544,7 +542,9 @@ function merge_transfer!(
     end
     # The width of new blocks is always next_growth_rate. So we need only add densities and
     # adjust for new width
-    @inbounds new_density::Float64 = sum(@view(smallest_class.block_densities[final_index:end]))
+    @inbounds new_density::Float64 = sum(
+        @view(smallest_class.block_densities[final_index:end])
+    )
     new_density *= smallest_growth_rate / next_growth_rate
 
     add_block!(

--- a/src/timestep.jl
+++ b/src/timestep.jl
@@ -204,7 +204,9 @@ function apply_mortality!(
     return nothing
 end
 function apply_mortality!(size_class::SizeClass, survival_rate::Float64)::Nothing
-    size_class.block_densities .*= survival_rate
+    @inbounds for i ∈ eachindex(size_class.block_densities)
+        size_class.block_densities[i] *= survival_rate
+    end
 
     return nothing
 end
@@ -223,8 +225,10 @@ function _apply_internal_growth!(
 end
 function _apply_internal_growth!(size_class::SizeClass, growth_rate::Float64)::Nothing
     # Apply growth directly to underlying buffer
-    size_class.block_lower_bounds .+= growth_rate
-    size_class.block_upper_bounds .+= growth_rate
+    @inbounds for i ∈ eachindex(size_class.block_lower_bounds)
+        size_class.block_lower_bounds[i] += growth_rate
+        size_class.block_upper_bounds[i] += growth_rate
+    end
 
     # Grow upper bounds and clamp bounds by upper bound of size class
     class_upper_bound::Float64 = size_class.upper_bound
@@ -630,17 +634,17 @@ end
 function coral_cover(
     functional_group::Vector{FunctionalGroup}, C_cover::SubArray{Float64, 2}
 )::Nothing
-    # for (i, grp) in enumerate(functional_group)
-    #     coral_cover(grp, @view(C_cover[i, :]))
-    # end
-    coral_cover.(functional_group, eachrow(C_cover))
+    for (i, grp) ∈ enumerate(functional_group)
+        coral_cover(grp, @view(C_cover[i, :]))
+    end
+    # coral_cover.(functional_group, eachrow(C_cover))
 
     return nothing
 end
 function coral_cover(
     functional_group::FunctionalGroup, C_cover::SubArray{Float64, 1}
 )::Nothing
-    C_cover[1:(end - 1)] .= coral_cover.(functional_group.size_classes)
+    @. C_cover[1:(end - 1)] = coral_cover(functional_group.size_classes)
     C_cover[end] =
         functional_group.terminal_class.density *
         average_area(functional_group.terminal_class)
@@ -648,8 +652,7 @@ function coral_cover(
 end
 function coral_cover(size_class::SizeClass)::Float64
     cover::Float64 = 0.0
-    #? I think we could broadcast this operation
-    for i ∈ 1:n_blocks(size_class)
+    @inbounds for i ∈ 1:n_blocks(size_class)
         cover +=
             size_class.block_densities[i] * π / 12 *
             (size_class.block_upper_bounds[i]^3 - size_class.block_lower_bounds[i]^3)


### PR DESCRIPTION
This PR reduces allocations and per-timestep recomputation in the hot paths of CoralBlox.jl.

`linear_extension.jl` introduces a `LinearExtensionCache` struct that pre-computes the three constant Δd matrices (Δ¹d, Δ²d, Δ³d) once per domain/scenario. A new public overload accepts the cache directly so callers in a timestep loop avoid recomputing these matrices on every call. The scalar implementation is refactored into a private `_linear_extension_scale_factors_core` that fuses projected-cover estimation and quadratic coefficient accumulation into a single loop, eliminating all intermediate matrix allocations.

`timestep.jl` replaces the linear scan in transfer_blocks! with a searchsortedfirst binary search, exploiting the fact that block_upper_bounds is maintained in descending order. 

Broadcast mutations (`.*=`, `.+=`) in `apply_mortality!` and `_apply_internal_growth!` are replaced with explicit `@inbounds` scalar loops, and `@inbounds` is added to the accumulation loop in `coral_cover(SizeClass)`. 

The `coral_cover(Vector{FunctionalGroup})` broadcast is replaced with an explicit enumerate loop using `@view` slices. 

Finally, the `SizeClass` default buffer capacity is reduced from 256 to 16 (the buffer grows dynamically; the old default wasted memory at construction time), `num_sc` is simplified to avoid a temporary slice allocation.

A duplicate return statement in `FunctionalGroup` was removed.